### PR TITLE
Add top crates testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "smallvec",
+ "toml",
 ]
 
 [[package]]
@@ -811,6 +812,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +958,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1248,6 +1292,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ lazy_static = "1.4.0"
 petgraph = "0.6.5"
 bumpalo = "3.16.0"
 
-
 [dev-dependencies]
 reqwest = { version = "^0.11", features = ["blocking"] }
+toml = "0.7"
 
 [package.metadata.rust-analyzer]
 # This crate uses #[feature(rustc_private)]

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ To view the visualization
 
 Once the server is running, you can keep it running and analyze other files
 (e.g. `cargo run [FILENAME2].rs`). Just refresh the page to see updated results.
+
+To run on the top crates use:
+
+`cargo test --package pcs --test top_crates -- top_crates --exact --show-output`

--- a/src/borrows/borrows_visitor.rs
+++ b/src/borrows/borrows_visitor.rs
@@ -566,7 +566,7 @@ impl<'tcx, 'mir, 'state> Visitor<'tcx> for BorrowsVisitor<'tcx, 'mir, 'state> {
             | Aggregate(_, _)
             | ShallowInitBox(_, _) => {}
 
-            &Ref(_, _, place) | &Len(place) | &Discriminant(place) | &CopyForDeref(place) => {
+            &Ref(_, _, place) | &RawPtr(_, place) | &Len(place) | &Discriminant(place) | &CopyForDeref(place) => {
                 let place: utils::Place<'tcx> = place.into();
                 if self.before && self.preparing && !place.is_owned(self.body, self.tcx) {
                     self.ensure_expansion_to_exactly(place, location);

--- a/src/free_pcs/impl/triple.rs
+++ b/src/free_pcs/impl/triple.rs
@@ -128,14 +128,14 @@ impl<'tcx> Visitor<'tcx> for TripleWalker<'tcx> {
             | Aggregate(_, _)
             | ShallowInitBox(_, _) => {}
 
-            &Ref(_, _, place) | &Len(place) | &Discriminant(place) | &CopyForDeref(place) => {
+            &Ref(_, _, place) | &RawPtr(_, place) | &Len(place) | &Discriminant(place) | &CopyForDeref(place) => {
                 let triple = Triple {
                     pre: Condition::exclusive(place),
                     post: None,
                 };
                 self.operand_triples.push(triple);
             }
-            _ => todo!(),
+            _ => todo!("{rvalue:?}"),
         }
     }
 

--- a/src/utils/repacker.rs
+++ b/src/utils/repacker.rs
@@ -423,7 +423,7 @@ impl<'tcx> Place<'tcx> {
                         .into(),
                 );
             }
-            ty => unreachable!("ty={:?}", ty),
+            ty => unreachable!("ty={:?} ({self:?})", ty),
         }
         places
     }

--- a/src/visualization/mir_graph.rs
+++ b/src/visualization/mir_graph.rs
@@ -86,7 +86,7 @@ fn format_operand<'tcx>(operand: &Operand<'tcx>, repacker: PlaceRepacker<'_, 'tc
 fn format_rvalue<'tcx>(rvalue: &Rvalue<'tcx>, repacker: PlaceRepacker<'_, 'tcx>) -> String {
     match rvalue {
         Rvalue::Use(operand) => format_operand(operand, repacker),
-        Rvalue::Repeat(_, _) => todo!(),
+        Rvalue::Repeat(operand, c) => format!("repeat {} {}", format_operand(operand, repacker), c),
         Rvalue::Ref(_region, kind, place) => {
             let kind = match kind {
                 mir::BorrowKind::Shared => "",
@@ -94,6 +94,13 @@ fn format_rvalue<'tcx>(rvalue: &Rvalue<'tcx>, repacker: PlaceRepacker<'_, 'tcx>)
                 mir::BorrowKind::Fake(_) => todo!(),
             };
             format!("&{} {}", kind, format_place(place, repacker))
+        }
+        Rvalue::RawPtr(kind, place) => {
+            let kind = match kind {
+                mir::Mutability::Mut => "mut",
+                mir::Mutability::Not => "const",
+            };
+            format!("*{} {}", kind, format_place(place, repacker))
         }
         Rvalue::ThreadLocalRef(_) => todo!(),
         Rvalue::Len(_) => todo!(),

--- a/tests/top_crates.rs
+++ b/tests/top_crates.rs
@@ -1,0 +1,169 @@
+use serde_derive::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[test]
+pub fn top_crates() {
+    top_crates_range(0..500)
+}
+
+fn get(url: &str) -> reqwest::Result<reqwest::blocking::Response> {
+    println!("Getting: {url}");
+    reqwest::blocking::ClientBuilder::new()
+        .user_agent("Rust Corpus - Top Crates Scrapper")
+        .build()?
+        .get(url)
+        .send()
+}
+
+pub fn top_crates_range(range: std::ops::Range<usize>) {
+    std::fs::create_dir_all("tmp").unwrap();
+    let top_crates = CratesIter::top(range);
+    for (i, krate) in top_crates {
+        let version = krate.version.unwrap_or(krate.newest_version);
+        println!("Starting: {i} ({})", krate.name);
+        run_on_crate(&krate.name, &version);
+    }
+}
+
+pub fn get_rust_toolchain_channel() -> String {
+    #[derive(Deserialize)]
+    struct RustToolchainFile {
+        toolchain: RustToolchain,
+    }
+
+    #[derive(Deserialize)]
+    struct RustToolchain {
+        channel: String,
+        #[allow(dead_code)]
+        components: Option<Vec<String>>,
+    }
+
+    let content = include_str!("../rust-toolchain");
+    // Be ready to accept TOML format
+    // See: https://github.com/rust-lang/rustup/pull/2438
+    if content.starts_with("[toolchain]") {
+        let rust_toolchain: RustToolchainFile =
+            toml::from_str(content).expect("failed to parse rust-toolchain file");
+        rust_toolchain.toolchain.channel
+    } else {
+        content.trim().to_string()
+    }
+}
+
+fn run_on_crate(name: &str, version: &str) {
+    let dirname = format!("./tmp/{name}-{version}");
+    let filename = format!("{dirname}.crate");
+    if !std::path::PathBuf::from(&filename).exists() {
+        let dl = format!("https://crates.io/api/v1/crates/{name}/{version}/download");
+        let mut resp = get(&dl).expect("Could not fetch top crates");
+        let mut file = std::fs::File::create(&filename).unwrap();
+        resp.copy_to(&mut file).unwrap();
+    }
+    println!("Unwrapping: {filename}");
+    let status = std::process::Command::new("tar")
+        .args(["-xf", &filename, "-C", "./tmp/"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open(format!("{dirname}/Cargo.toml"))
+        .unwrap();
+    use std::io::Write;
+    writeln!(file, "\n[workspace]").unwrap();
+    let cwd = std::env::current_dir().unwrap();
+    assert!(
+        cfg!(debug_assertions),
+        "Must be run in debug mode, to enable full checking"
+    );
+    let target = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let cargo = "cargo";
+    let pcs_exe = cwd.join(
+        ["target", target, "pcs_bin"]
+            .iter()
+            .collect::<PathBuf>(),
+    );
+    println!("Running: {pcs_exe:?}");
+    let exit = std::process::Command::new(cargo)
+        .arg("check")
+        .env("RUST_TOOLCHAIN", get_rust_toolchain_channel())
+        .env("RUSTUP_TOOLCHAIN", get_rust_toolchain_channel())
+        .env("RUSTC", pcs_exe)
+        .current_dir(&dirname)
+        .status()
+        .unwrap();
+    assert!(exit.success());
+    std::fs::remove_dir_all(dirname).unwrap();
+}
+
+/// A create on crates.io.
+#[derive(Debug, Deserialize, Serialize)]
+struct Crate {
+    #[serde(rename = "id")]
+    name: String,
+    #[serde(rename = "max_stable_version")]
+    version: Option<String>,
+    #[serde(rename = "newest_version")]
+    newest_version: String,
+}
+
+/// The list of crates from crates.io
+#[derive(Debug, Deserialize)]
+struct CratesList {
+    crates: Vec<Crate>,
+}
+
+const PAGE_SIZE: usize = 100;
+struct CratesIter {
+    curr_idx: usize,
+    curr_page: usize,
+    crates: Vec<Crate>,
+}
+
+impl CratesIter {
+    pub fn new(start: usize) -> Self {
+        Self {
+            curr_idx: start,
+            curr_page: start / PAGE_SIZE + 1,
+            crates: Vec::new(),
+        }
+    }
+    pub fn top(range: std::ops::Range<usize>) -> impl Iterator<Item = (usize, Crate)> {
+        Self::new(range.start).take(range.len())
+    }
+}
+
+impl Iterator for CratesIter {
+    type Item = (usize, Crate);
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.crates.is_empty() {
+            let url = format!(
+                "https://crates.io/api/v1/crates?page={}&per_page={PAGE_SIZE}&sort=downloads",
+                self.curr_page,
+            );
+            let resp = get(&url).expect("Could not fetch top crates");
+            assert!(
+                resp.status().is_success(),
+                "Response status: {}",
+                resp.status()
+            );
+            let page_crates: CratesList = match serde_json::from_reader(resp) {
+                Ok(page_crates) => page_crates,
+                Err(e) => panic!("Invalid JSON {e}"),
+            };
+            assert_eq!(page_crates.crates.len(), PAGE_SIZE);
+            self.crates = page_crates.crates;
+            self.crates.reverse();
+            self.crates
+                .truncate(self.crates.len() - self.curr_idx % PAGE_SIZE);
+            self.curr_page += 1;
+        }
+        self.curr_idx += 1;
+        Some((self.curr_idx - 1, self.crates.pop().unwrap()))
+    }
+}


### PR DESCRIPTION
Adds a test which runs pcs on top n crates. We should aim to make the PCS not crash on any of these. Ideally, we would add a checker which executes all the commands the PCS comes up with (i.e. unfold/fold/apply etc.) as well as the triples of the statements to verify that the commands are valid and do actually result in states which satisfy the pres.